### PR TITLE
[Security Solution] fixes for the Threat Hunting Investigations team

### DIFF
--- a/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/search_bar/integrations_filter_button.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/detections/components/alert_summary/search_bar/integrations_filter_button.tsx
@@ -108,7 +108,7 @@ export const IntegrationFilterButton = memo(({ integrations }: IntegrationFilter
   );
 
   return (
-    <EuiFilterGroup>
+    <EuiFilterGroup compressed={true}>
       <EuiPopover
         button={button}
         closePopover={togglePopover}

--- a/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/trigger.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/sourcerer/components/trigger.tsx
@@ -7,7 +7,7 @@
 
 import type { FC } from 'react';
 import React, { memo, useMemo } from 'react';
-import { EuiToolTip, EuiButton } from '@elastic/eui';
+import { EuiButton, EuiToolTip } from '@elastic/eui';
 import * as i18n from './translations';
 import { getTooltipContent, StyledBadge, StyledButtonEmpty } from './helpers';
 import type { ModifiedTypes } from './use_pick_index_patterns';
@@ -84,6 +84,7 @@ export const TriggerComponent: FC<Props> = ({
         disabled={disabled}
         isLoading={loading}
         onClick={onClick}
+        size="s"
         title={i18n.DATA_VIEW}
       >
         {i18n.DATA_VIEW}

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/date_picker_lock/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/date_picker_lock/index.tsx
@@ -37,17 +37,17 @@ const TimelineDatePickerLockComponent = () => {
       }
     >
       <EuiButtonIcon
-        data-test-subj={`timeline-date-picker-${isDatePickerLocked ? 'lock' : 'unlock'}-button`}
-        color="primary"
-        size="m"
-        onClick={onToggleLock}
-        iconType={isDatePickerLocked ? 'lock' : 'lockOpen'}
-        display={isDatePickerLocked ? 'fill' : 'base'}
         aria-label={
           isDatePickerLocked
             ? i18n.UNLOCK_SYNC_MAIN_DATE_PICKER_ARIA
             : i18n.LOCK_SYNC_MAIN_DATE_PICKER_ARIA
         }
+        color="primary"
+        data-test-subj={`timeline-date-picker-${isDatePickerLocked ? 'lock' : 'unlock'}-button`}
+        display={isDatePickerLocked ? 'fill' : 'base'}
+        iconType={isDatePickerLocked ? 'lock' : 'lockOpen'}
+        onClick={onToggleLock}
+        size="s"
       />
     </EuiToolTip>
   );

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/search_or_filter.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/search_or_filter/search_or_filter.tsx
@@ -149,14 +149,14 @@ export const SearchOrFilter = React.memo<Props>(
                 <EuiFlexItem grow={false}>
                   <EuiToolTip content={dataProviderIconTooltipContent} disableScreenReaderOutput>
                     <EuiButtonIcon
-                      color={buttonColor}
-                      isSelected={isDataProviderVisible}
-                      iconType="timeline"
-                      data-test-subj="toggle-data-provider"
-                      size="m"
-                      display="base"
                       aria-label={dataProviderIconTooltipContent}
+                      color={buttonColor}
+                      data-test-subj="toggle-data-provider"
+                      display="base"
+                      iconType="timeline"
+                      isSelected={isDataProviderVisible}
                       onClick={toggleDataProviderVisibility}
+                      size="s"
                     />
                   </EuiToolTip>
                 </EuiFlexItem>
@@ -168,10 +168,11 @@ export const SearchOrFilter = React.memo<Props>(
 
             <EuiFlexItem grow={false} data-test-subj="timeline-date-picker-container">
               <SuperDatePicker
-                width="auto"
+                compressed={true}
+                disabled={false}
                 id={InputsModelId.timeline}
                 timelineId={timelineId}
-                disabled={false}
+                width="auto"
               />
             </EuiFlexItem>
           </EuiFlexGroup>

--- a/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/header/index.tsx
+++ b/x-pack/solutions/security/plugins/security_solution/public/timelines/components/timeline/tabs/eql/header/index.tsx
@@ -59,7 +59,12 @@ export const EqlTabHeader = memo(
                 ))}
             </EuiFlexItem>
             <EuiFlexItem>
-              <SuperDatePicker width="auto" id={InputsModelId.timeline} timelineId={timelineId} />
+              <SuperDatePicker
+                compressed={true}
+                id={InputsModelId.timeline}
+                timelineId={timelineId}
+                width="auto"
+              />
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <TimelineDatePickerLock />


### PR DESCRIPTION
## Summary

This PR fixes a few UI issues introduced by [this PR](https://github.com/elastic/kibana/pull/231659) that changed the height of the search bar.

For Timeline, we have the Query tab that uses the search component, and some of the components on the sides of it were not updated to a smaller height

| Before | After |
| ------------- | ------------- |
| <img width="1404" height="481" alt="timeline-query-before" src="https://github.com/user-attachments/assets/da2dbfa2-9650-4646-ab80-c2483bb6ce09" /> | <img width="1418" height="517" alt="timeline-query-after" src="https://github.com/user-attachments/assets/46b7199e-8f64-4286-8c79-68a86ed75e49" /> |

After making the changes to fix the tab above, changes had to be made on the Correlation tab as some components are shared between the 2 tabs

| Before | After |
| ------------- | ------------- |
| <img width="1403" height="443" alt="timeline-correlation-before" src="https://github.com/user-attachments/assets/75624231-c7c8-4b3b-94a3-b5e36f7d12f7" /> | <img width="1412" height="524" alt="timeline-correlation-after" src="https://github.com/user-attachments/assets/e70d7aab-5f7b-4857-a7d2-c54edfdefe72" /> |

Finally, the Alert summary page on the EASE/AI4DSOC project also needed a small adjustment

| Before | After |
| ------------- | ------------- |
| <img width="1413" height="727" alt="ease-alert-summary-before" src="https://github.com/user-attachments/assets/e610eb5c-3e12-4672-b69b-c6ed376a655a" /> | <img width="1366" height="554" alt="ease-alert-summary-after" src="https://github.com/user-attachments/assets/1acf7f34-1712-4996-bd51-cd1b065a0404" /> |