### PR TITLE
[SLO] fix slo index selector and timestamp field

### DIFF
--- a/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
+++ b/src/platform/plugins/shared/unified_search/public/dataview_picker/change_dataview.tsx
@@ -316,6 +316,7 @@ export function ChangeDataView({
                 initialFocus={`[id="${searchListInputId}"]`}
                 display="block"
                 buffer={8}
+                css={{ inlineSize: '100%' }}
               >
                 <div css={styles.popoverContent}>
                   <EuiContextMenuPanel size="s" items={items} />

--- a/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/common/timestamp_field_selector.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/pages/slo_edit/components/common/timestamp_field_selector.tsx
@@ -48,6 +48,7 @@ export function TimestampFieldSelector({ fields, isDisabled, isLoading }: Props)
           return (
             <EuiComboBox<string>
               {...field}
+              compressed
               async
               placeholder={placeholder}
               aria-label={placeholder}


### PR DESCRIPTION
## Summary

This PR fixes two UI issues in the UI of the SLO create form introduced by this [PR](https://github.com/elastic/kibana/pull/231659):

- the index selector should take fullWidth
- the timestamp field should have a compressed height

### Before

<img width="600" height="83" alt="Screenshot 2025-09-19 at 20 01 36" src="https://github.com/user-attachments/assets/4a7ad74f-d296-4c4a-b89a-29122de69999" />

### After

<img width="600" height="119" alt="Screenshot 2025-09-19 at 22 26 33" src="https://github.com/user-attachments/assets/d35591ca-e6a9-44b6-ae0c-f3c0c83b5b35" />


@olapawlus I changed the core `ChangeDataView` component, so I don't know if I would break some other page with this fix. I tested a few other pages to see if things are broken and it looks good. Feel free to change it, if you have a better fix.


